### PR TITLE
Changed separator in synthesized mixture names

### DIFF
--- a/.sources.json
+++ b/.sources.json
@@ -1,0 +1,50 @@
+{
+  "mixtures": [
+    {
+      "name": "He",
+      "composition": {
+        "He": 1.0
+      }
+    },
+    {
+      "name": "CO/He",
+      "composition": {
+        "CO": "10 %",
+        "He": 0.9
+      }
+    },
+    {
+      "name": "NO/He",
+      "composition": {
+        "NO": "4 %",
+        "He": 0.96
+      }
+    },
+    {
+      "name": "H2",
+      "composition": {
+        "H2": 1.0
+      }
+    },
+    {
+      "name": "O2/N2",
+      "composition": {
+        "O2": "21 %",
+        "N2": 0.79
+      }
+    },
+    {
+      "name": "O2/He",
+      "composition": {
+        "O2": "21 %",
+        "He": 0.79
+      }
+    },
+    {
+      "name": "N2",
+      "composition": {
+        "N2": 1.0
+      }
+    }
+  ]
+}

--- a/mfclib/cli.py
+++ b/mfclib/cli.py
@@ -100,6 +100,13 @@ def format_final_value(value, soll_value):
     callback=validate_temperature,
     help="Temperature of mixed flow.",
 )
+@click.option(
+    "--Tref",
+    default="273K",
+    show_default=True,
+    callback=validate_temperature,
+    help="Calibration temperature of MFCs.",
+)
 @click.option("-o", "--output", type=Path)
 @click.option("--markdown", is_flag=True, default=False)
 def flowmix(mixture: mfclib.Mixture, **kws):
@@ -122,6 +129,9 @@ def flowmix(mixture: mfclib.Mixture, **kws):
     # get options
     flowrate = kws['flowrate']
     temperature = kws['temperature']
+    Tref = kws['tref']
+    print(Tref)
+    print(kws)
     emit_markdown = kws['markdown']
 
     # list of all species
@@ -134,7 +144,7 @@ def flowmix(mixture: mfclib.Mixture, **kws):
     flow_rates = mfclib.supply_proportions_for_mixture(sources, mixture)
     flow_rates *= flowrate
 
-    T_ratio = ureg.Quantity("273.15K") / temperature
+    T_ratio = Tref / temperature
     std_flow_rates = flow_rates * T_ratio
 
     # final mixture composition
@@ -164,9 +174,9 @@ def flowmix(mixture: mfclib.Mixture, **kws):
         justify="right",
     )
     table.add_column(
-        f"flow rate @ 273K", footer=f"{sum(std_flow_rates)}", justify="right"
+        f"flow rate @ {Tref}", footer=f"{sum(std_flow_rates)}", justify="right"
     )
-    table.add_column(f"N2 flow rate @ 273K", justify="right")
+    table.add_column(f"N2 flow rate @ {Tref}", justify="right")
     for k, source in enumerate(sources):
         table.add_row(
             source.name,

--- a/mfclib/mixture.py
+++ b/mfclib/mixture.py
@@ -97,7 +97,7 @@ class Mixture(pydantic.BaseModel, collections.abc.Mapping):
     @pydantic.model_validator(mode='after')
     def check_name(self):
         if not self.name:
-            self.name = "|".join(self.composition.keys())
+            self.name = "/".join(self.composition.keys())
         return self
 
     @pydantic.field_validator('composition', mode='before')

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -91,7 +91,7 @@ class TestMixture:
         mfc = Mixture.from_kws(N2=0.79, O2=0.21)
         assert mfc.composition == dict(N2=0.79, O2=0.21)
         assert dict(mfc) == dict(N2=0.79, O2=0.21)
-        assert mfc.name == 'N2|O2'
+        assert mfc.name == 'N2/O2'
 
     def test_create_with_balanced_feed(self):
         mfc = Mixture(composition=dict(N2='*', O2=0.21), name='carrier')
@@ -100,10 +100,10 @@ class TestMixture:
 
     def test_synthesize_name(self):
         mixture = Mixture(composition=dict(NO=0.003, Ar='*'))
-        assert mixture.name == 'NO|Ar'
+        assert mixture.name == 'NO/Ar'
 
         mixture = Mixture(composition=dict(Ar='*', NO=0.003))
-        assert mixture.name == 'Ar|NO'
+        assert mixture.name == 'Ar/NO'
 
     def test_conversion_factor(self):
         mfc = Mixture(composition=dict(N2=0.79, O2=0.21))


### PR DESCRIPTION
Seperator `|` has been replaced with `/` because the vertical line collided with the column separator in markdown tables.